### PR TITLE
FIX PropTypes

### DIFF
--- a/lib/ScrollViewSmart.js
+++ b/lib/ScrollViewSmart.js
@@ -1,7 +1,7 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 import {
   Platform,
   Keyboard,


### PR DESCRIPTION
React.PropTypes is deprecated as of React v15.5